### PR TITLE
fix endpoint var and added ignore_ssl

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     ns1 = {
       source = "ns1-terraform/ns1"
+      version = ">= 1.9.3"
     }
   }
   required_version = ">= 0.13"
@@ -10,6 +11,8 @@ terraform {
 provider "ns1" {
    apikey = var.apikey
    rate_limit_parallelism = var.rate_limit_parallelism
+   endpoint = var.endpoint
+   ignore_ssl = var.ignore_ssl
 }
 
 resource "ns1_zone" "nia_zones" {

--- a/variable.tf
+++ b/variable.tf
@@ -21,6 +21,12 @@ variable "endpoint" {
   default     = "https://api.nsone.net/v1/"
 }
 
+variable "ignore_ssl" {
+  description = "(Optional) This normally does not need to be set."
+  type        = bool
+  default     = false
+}
+
 variable "services" {
   description = "Consul services monitored by Consul NIA"
   type = map(


### PR DESCRIPTION
- Fix missing endpoint var on NS1 Provider
- Added ignore_ssl var (usually to be used on dev environments)